### PR TITLE
Add development and production proxy to node server

### DIFF
--- a/Trials.com/react-frontend/package.json
+++ b/Trials.com/react-frontend/package.json
@@ -1,6 +1,5 @@
 {
   "name": "test-app",
-	"proxy": "http://66.42.118.153/",
   "version": "0.1.0",
   "private": true,
   "dependencies": {

--- a/Trials.com/react-frontend/src/index.tsx
+++ b/Trials.com/react-frontend/src/index.tsx
@@ -1,5 +1,7 @@
 import React from "react";
 import ReactDOM from "react-dom";
 import App from "./App";
+import axios from "axios";
 
+axios.defaults.baseURL = "http://66.42.118.153/api";
 ReactDOM.render(<App />, document.getElementById("root"));

--- a/Trials.com/react-frontend/src/server.js
+++ b/Trials.com/react-frontend/src/server.js
@@ -15,6 +15,15 @@ app.use(
     extended: true,
   })
 );
+app.use(function (req, res, next) {
+  console.log(JSON.stringify(req.headers));
+  res.header("Access-Control-Allow-Origin", "*");
+  res.header(
+    "Access-Control-Allow-Headers",
+    "Origin, X-Requested-With, Content-Type, Accept"
+  );
+  next();
+});
 
 DataRoute(app);
 SubmitRoute(app);


### PR DESCRIPTION
- server.js represents the node server that is running on a separate domain, its not actually being used here. Only to show the current state of the server on the other domain
- Change from react proxy in package,json to axios baseUrl and added CORS policy within the server.js file